### PR TITLE
fix: rectify the contents of the code block in the protected route

### DIFF
--- a/pages/documents/[id].js
+++ b/pages/documents/[id].js
@@ -73,52 +73,68 @@ export default function DocumentRoute({ data }) {
           <p>{data.blurb}</p>
           {data.icon ? <img src={`/icons/${data.icon}.svg`} alt="" /> : null}
 
-          <h4>The load function for this document page:</h4>
+          <h4>The getServerSideProps function for this document page:</h4>
           <Prism
-            source={`export let loader: LoaderFunction = async (args) => {
-    // fetch the user from the session
-    const user = await requireUser(args);
-  
-    // cerbos requires an array of \`roles\` so we just wrap \`role\` in an array
-    const roles = user.publicMetadata.role ? [user.publicMetadata.role as string] : [];
-    const { params } = args;
-  
-    if (!params.id) {
-      throw json('Document ID required', { status: 400 });
-    }
-  
-    // query for the minimal infomation needed to pass to cerbos for an authorization check
-    const documentAttrs = await getDocumentAttributesById(params.id);
-  
-    // if we can't find a document matching the route param id, throw a 404
-    if (!documentAttrs) {
-      throw json('Not Found', { status: 404 });
-    }
-  
-    // ** fake the ownership of the document for the purposes of this demo **
-    if (documentAttrs?.author === 'tbd') {
-      documentAttrs.author = user.id;
-    }
-  
-    const isAllowed = await cerbos.isAllowed({
-      principal: { id: user.id, roles },
-      resource: {
-        kind: 'document',
-        id: params.id,
-        attributes: documentAttrs,
+            source={`export async function getServerSideProps({ req, params }) {
+  // fetch the user from the session
+  const { userId } = getAuth(req);
+  const user = userId ? await clerkClient.users.getUser(userId) : null;
+
+  // cerbos requires an array of \`roles\` so we just wrap \`role\` in an array
+  const roles = user.publicMetadata.role ? [user.publicMetadata.role] : [];
+
+  // query for the minimal infomation needed to pass to cerbos for an authorization check
+  const documentAttrs = await getDocumentAttributesById(params.id);
+
+  // if we can't find a document matching the route param id, throw a 404
+  if (!documentAttrs) {
+    return {
+      props: {
+        error: {
+          message: "Document not found",
+          statusCode: 404,
+        },
       },
-      action: 'view',
-    });
-  
-    if (!isAllowed) {
-      throw json('Forbidden', { status: 403 });
-    }
-  
-    // get the full document for the page
-    const document = await getDocumentById(params.id);
-  
-    return json(document);
+    };
+  }
+
+  // ** fake the ownership of the document for the purposes of this demo **
+  if (documentAttrs?.author === "tbd") {
+    documentAttrs.author = userId;
+  }
+
+  const isAllowed = await cerbos.isAllowed({
+    principal: { id: user.id, roles },
+    resource: {
+      kind: "document",
+      id: params.id,
+      attributes: documentAttrs,
+    },
+    action: "view",
+  });
+
+  if (!isAllowed) {
+    return {
+      props: {
+        error: {
+          message: "Forbidden",
+          statusCode: 403,
+        },
+      },
+    };
+  }
+
+  // get the full document for the page
+  const document = await getDocumentById(params.id);
+
+  return {
+    props: {
+      data: document,
+      ...buildClerkProps(req),
+    },
   };
+}
+
   `}
           />
         </div>


### PR DESCRIPTION
Contents of the code block within `documents/[id]` page seem to be copied over from Remix example. This PR corrects that with the actual code block that is used in the example